### PR TITLE
adds -keep-original CLI option to retain staging files, fixes #1

### DIFF
--- a/mpt/__main__.py
+++ b/mpt/__main__.py
@@ -92,6 +92,8 @@ def main(args=None):
                               help="keep empty folders in staging directory after completion")
     stage_parser.add_argument("-d", "--destinations", required=True, dest="targets", nargs="+", metavar="DESTINATIONS",
                               help="list of destination directories into which the files should be staged")
+    stage_parser.add_argument("--keep-original", dest="remove_original", action="store_false", default=remove_original,
+                              help="keep staging files after completion")
 
     # Common args
 

--- a/mpt/defaults.py
+++ b/mpt/defaults.py
@@ -9,3 +9,4 @@ mail_size_threshold = 10000000
 max_failures = 10
 fallback_to_insecure_smtp = False
 email_only_exceptions = True
+remove_original = True

--- a/mpt/staging.py
+++ b/mpt/staging.py
@@ -27,9 +27,9 @@ class FileStager():
     def __init__(self,
                  source: str,
                  destinations: List,
+                 remove_original: bool,
                  algorithm: str = default_algorithm,
-                 blocksize: int = default_blocksize,
-                 remove_original: bool = True):
+                 blocksize: int = default_blocksize):
         """
         Initialise the class instance
         :param source: path to the source filename
@@ -336,13 +336,14 @@ def _count_files(path: str, formats: List = None, recursive: bool = True):
     return count
 
 
-def _get_files_to_stage(directory: str, target_roots: List, checksum_roots: List, manifest_files: List,
+def _get_files_to_stage(directory: str, target_roots: List, checksum_roots: List, manifest_files: List, remove_original: bool,
                         algorithm: str = None, formats: List = None, recursive: bool = True):
     """ Create a generator to iterate all files in a directory
     :param directory: the root directory to traverse
     :param target_roots: a list of root directories to which the file should be copied
     :param checksum_roots: a list of root directories in which checksums should be created
     :param manifest_files: a list of manifest files to update
+    :param remove_original: a bool which removes or retains the original staging files
     :param algorithm: the algorithm to use for hashing
     :param formats: a list of file endings to list; if omitted, list all files
     :param recursive: true if listing should include sub-directories
@@ -382,7 +383,8 @@ def _get_files_to_stage(directory: str, target_roots: List, checksum_roots: List
                 file = {
                     "source": source_file,
                     "algorithm": algorithm,
-                    "destinations": dest_dicts
+                    "destinations": dest_dicts,
+                    "remove_original": remove_original
                 }
                 yield(file)
             if not recursive:
@@ -420,7 +422,7 @@ def _stage_file(next_file: Dict):
     :return: a triple consisting of the original file name, the staging status, and the details of all destinations
     """
     fs = FileStager(source=next_file["source"], destinations=next_file["destinations"],
-                    algorithm=next_file["algorithm"])
+                    algorithm=next_file["algorithm"], remove_original=next_file["remove_original"])
     fs.start_copy()
     if fs.completed():
         result = (next_file["source"], "staged", fs.destinations)
@@ -509,7 +511,7 @@ def stage_files(args: Namespace):
     # Build a generator to list all files to be staged, along with their staging destinations, checksum
     # destination and manifest files
     files_iterable = _get_files_to_stage(directory=args.dir, target_roots=targets, checksum_roots=checksums,
-                                         manifest_files=args.manifests)
+                                         manifest_files=args.manifests, remove_original=args.remove_original)
 
     # Create a multiprocessing pool with the appropriate number of processes
     pool = multiprocessing.Pool(processes=args.processes)


### PR DESCRIPTION
This is an attempt for fix #1 . I'm sure that there were many ways to do this but here's a summary of my changes:

* The `FileStager` class in `staging.py` no longer sets the default as True for `remove_original`, this is now done in `defaults.py`
* A `--keep-original` argument was added which sets the `remove_original` value to be `False`. I tried a few ways of doing this and this seemed like the least worst method.
* Some re-arragement of arguments in `staging.py` had to be done so that the args with defaults came last.
* Seeing as the `FileStager` class was only initiated in `_stage_file`, I took the perhaps incorrect route of adding `remove_original` value to `files_iterable` which allowed the information to eventually be present when initialising `FileStager`

In terms of testing - On Windows I used staging to move a folder to one other output directory. Adding `--keep-original` resulted in my source staging remaining intact, while removing this option resulted in the default behaiour prior to this patch - the source files are deleted after successful completion.